### PR TITLE
fix(settings): handle nop mode results when check run is missing

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -206,7 +206,7 @@ class Settings {
     // A nop run triggered outside the webhook flow (e.g. the full-sync entrypoint)
     // has no check run or repository in its payload, so there is nowhere to post
     // the results other than the log.
-    if (!payload?.check_run) {
+    if (!payload?.check_run || !payload?.repository) {
       this.log.info(`Dry-run results:\n${JSON.stringify(this.results, null, 2)}`)
       return
     }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -209,7 +209,8 @@ class Settings {
     // the log instead. The full diff can contain config values (e.g. Actions
     // variables), so it goes to debug; info gets a summary without them.
     if (!payload?.check_run || !payload?.repository) {
-      this.log.debug(`Dry-run results:\n${JSON.stringify(this.results, null, 2)}`)
+      // Passed as an object so the logger only serializes it when debug is emitted
+      this.log.debug({ results: this.results }, 'Dry-run results')
       const summary = this.results.map(res => `${res.type} ${res.plugin} ${res.repo}: ${res.action?.msg ?? ''}`).join('\n')
       this.log.info(`Dry-run finished with ${this.results.length} planned change(s); the full diff is logged at debug level.\n${summary}`)
       return

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -203,6 +203,14 @@ class Settings {
       })
     })
 
+    // A nop run triggered outside the webhook flow (e.g. the full-sync entrypoint)
+    // has no check run or repository in its payload, so there is nowhere to post
+    // the results other than the log.
+    if (!payload?.check_run) {
+      this.log.info(`Dry-run results:\n${JSON.stringify(this.results, null, 2)}`)
+      return
+    }
+
     let error = false
     // Different logic
     const stats = {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -204,10 +204,14 @@ class Settings {
     })
 
     // A nop run triggered outside the webhook flow (e.g. the full-sync entrypoint)
-    // has no check run or repository in its payload, so there is nowhere to post
-    // the results other than the log.
+    // can be missing the check run and repository webhook fields in its payload.
+    // If either is absent there is no check run to report to, so put the plan in
+    // the log instead. The full diff can contain config values (e.g. Actions
+    // variables), so it goes to debug; info gets a summary without them.
     if (!payload?.check_run || !payload?.repository) {
-      this.log.info(`Dry-run results:\n${JSON.stringify(this.results, null, 2)}`)
+      this.log.debug(`Dry-run results:\n${JSON.stringify(this.results, null, 2)}`)
+      const summary = this.results.map(res => `${res.type} ${res.plugin} ${res.repo}: ${res.action?.msg ?? ''}`).join('\n')
+      this.log.info(`Dry-run finished with ${this.results.length} planned change(s); the full diff is logged at debug level.\n${summary}`)
       return
     }
 

--- a/test/unit/lib/settings.test.js
+++ b/test/unit/lib/settings.test.js
@@ -576,7 +576,7 @@ repository:
 
         expect(stubContext.log.info).toHaveBeenCalledWith(expect.stringContaining('Changes found'))
         expect(stubContext.log.info).not.toHaveBeenCalledWith(expect.stringContaining('plain-value'))
-        expect(stubContext.log.debug).toHaveBeenCalledWith(expect.stringContaining('plain-value'))
+        expect(stubContext.log.debug).toHaveBeenCalledWith({ results: settings.results }, 'Dry-run results')
         expect(stubContext.octokit.rest.checks.update).not.toHaveBeenCalled()
       })
     })

--- a/test/unit/lib/settings.test.js
+++ b/test/unit/lib/settings.test.js
@@ -549,4 +549,48 @@ repository:
       expect(mockRepoSync).toHaveBeenCalledTimes(1)
     })
   }) // updateRepos - archived repo skipping
+
+  describe('handleResults', () => {
+    let settings
+
+    beforeEach(() => {
+      stubContext.octokit.rest.checks = { update: jest.fn().mockResolvedValue({}) }
+      stubContext.octokit.rest.issues = { createComment: jest.fn().mockResolvedValue({}) }
+      settings = new Settings(true, stubContext, mockRepo, {}, mockRef)
+      settings.results = [
+        {
+          type: 'INFO',
+          plugin: 'Branches',
+          repo: 'test/test-repo',
+          endpoint: '',
+          body: '',
+          action: { msg: 'Changes found', additions: {}, modifications: { branch: {} }, deletions: {} }
+        }
+      ]
+    })
+
+    describe('in nop mode without a check run in the payload (full sync)', () => {
+      it('logs the results instead of updating a check run', async () => {
+        // stubContext.payload only contains `installation`, like a full-sync context
+        await settings.handleResults()
+
+        expect(stubContext.log.info).toHaveBeenCalledWith(expect.stringContaining('Changes found'))
+        expect(stubContext.octokit.rest.checks.update).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('in nop mode with a check run in the payload (webhook flow)', () => {
+      it('completes the check run', async () => {
+        stubContext.payload.check_run = { id: 42, check_suite: { pull_requests: [{ number: 1 }] } }
+        stubContext.payload.repository = { owner: { login: 'test' }, name: 'test-repo' }
+
+        await settings.handleResults()
+
+        expect(stubContext.octokit.rest.checks.update).toHaveBeenCalledWith(expect.objectContaining({
+          check_run_id: 42,
+          status: 'completed'
+        }))
+      })
+    })
+  }) // handleResults
 }) // Settings Tests

--- a/test/unit/lib/settings.test.js
+++ b/test/unit/lib/settings.test.js
@@ -564,17 +564,19 @@ repository:
           repo: 'test/test-repo',
           endpoint: '',
           body: '',
-          action: { msg: 'Changes found', additions: {}, modifications: { branch: {} }, deletions: {} }
+          action: { msg: 'Changes found', additions: {}, modifications: { MY_VAR: { value: 'plain-value' } }, deletions: {} }
         }
       ]
     })
 
     describe('in nop mode without a check run in the payload (full sync)', () => {
-      it('logs the results instead of updating a check run', async () => {
+      it('logs a summary instead of updating a check run, keeping config values out of info', async () => {
         // stubContext.payload only contains `installation`, like a full-sync context
         await settings.handleResults()
 
         expect(stubContext.log.info).toHaveBeenCalledWith(expect.stringContaining('Changes found'))
+        expect(stubContext.log.info).not.toHaveBeenCalledWith(expect.stringContaining('plain-value'))
+        expect(stubContext.log.debug).toHaveBeenCalledWith(expect.stringContaining('plain-value'))
         expect(stubContext.octokit.rest.checks.update).not.toHaveBeenCalled()
       })
     })

--- a/test/unit/lib/settings.test.js
+++ b/test/unit/lib/settings.test.js
@@ -579,6 +579,17 @@ repository:
       })
     })
 
+    describe('in nop mode with a check run but no repository in the payload', () => {
+      it('logs the results instead of updating a check run', async () => {
+        stubContext.payload.check_run = { id: 42, check_suite: { pull_requests: [{ number: 1 }] } }
+
+        await settings.handleResults()
+
+        expect(stubContext.log.info).toHaveBeenCalledWith(expect.stringContaining('Changes found'))
+        expect(stubContext.octokit.rest.checks.update).not.toHaveBeenCalled()
+      })
+    })
+
     describe('in nop mode with a check run in the payload (webhook flow)', () => {
       it('completes the check run', async () => {
         stubContext.payload.check_run = { id: 42, check_suite: { pull_requests: [{ number: 1 }] } }


### PR DESCRIPTION
Fixes #818.

`syncInstallation` builds a minimal context whose payload only contains `installation`, but the nop branch of `handleResults` unconditionally reads `payload.check_run.id` and `payload.repository.owner.login` (and `payload.check_run.check_suite.pull_requests` when `CREATE_PR_COMMENT` is on). Those fields only exist in the webhook flow. This is the root cause @ctbui and @jamengual identified in the issue comments.

This change guards the nop reporting path: when the payload has no `check_run`, the deduplicated dry-run results are written to the log at info level and the check-run/PR-comment reporting is skipped. So a scheduled or CLI full sync in nop mode now completes and prints its plan instead of dying after doing all the work. The webhook flow is untouched, and non-nop runs don't go through this path at all.

#923 previously approached this by posting the results back to a PR via Actions env vars before it was closed. This PR is intentionally narrower: just stop crashing and put the plan in the log. Something like #923 could still layer nicer reporting on top later.

Added `handleResults` coverage: a nop run with a payload that lacks `check_run` resolves and logs the results without touching the checks API, and a nop run with a `check_run` still completes the check run as before (that path had no coverage either).