### PR TITLE
feat(logging): add info-level logging for applied configuration changes

### DIFF
--- a/lib/plugins/branches.js
+++ b/lib/plugins/branches.js
@@ -79,6 +79,8 @@ module.exports = class Branches extends ErrorStash {
                 this.log.debug(`There are changes for branch ${JSON.stringify(params)}\n ${JSON.stringify(changes)} \n Branch protection will be applied`)
                 if (this.nop) {
                   resArray.push(new NopCommand(this.constructor.name, this.repo, null, results))
+                } else {
+                  this.log.info(`Applying branch protection changes to ${params.branch} branch of ${this.repo.owner}/${this.repo.repo} (the diff is logged at debug level)`)
                 }
 
                 Object.assign(params, requiredBranchProtectionDefaults, this.reformatAndReturnBranchProtection(structuredClone(result.data)), Overrides.removeOverrides(overrides, branch.protection, result.data), { headers: previewHeaders })

--- a/lib/plugins/diffable.js
+++ b/lib/plugins/diffable.js
@@ -78,6 +78,8 @@ module.exports = class Diffable extends ErrorStash {
         } else {
           if (this.nop) {
             resArray.push(new NopCommand(this.constructor.name, this.repo, null, results, 'INFO'))
+          } else {
+            this.log.info(`Applying ${this.constructor.name} changes to ${this.repo.owner}/${this.repo.repo} (the diff is logged at debug level)`)
           }
         }
 

--- a/lib/plugins/repository.js
+++ b/lib/plugins/repository.js
@@ -77,11 +77,11 @@ module.exports = class Repository extends ErrorStash {
         // const results = JSON.stringify(changes, null, 2)
         const results = { msg: `${this.constructor.name} settings changes`, additions: changes.additions, modifications: changes.modifications, deletions: changes.deletions }
 
-        this.log.debug(`Result of comparing repo for changes = ${results}`)
+        this.log.debug(`Result of comparing repo for changes = ${JSON.stringify(results)}`)
 
         // const topicResults = JSON.stringify(topicChanges, null, 2)
         const topicResults = { msg: `${this.constructor.name} settings changes for topics`, additions: topicChanges.additions, modifications: topicChanges.modifications, deletions: topicChanges.deletions }
-        this.log.debug(`Result of comparing topics for changes source ${JSON.stringify(resp.data.topics)} target ${JSON.stringify(this.topics)} = ${topicResults}`)
+        this.log.debug(`Result of comparing topics for changes source ${JSON.stringify(resp.data.topics)} target ${JSON.stringify(this.topics)} = ${JSON.stringify(topicResults)}`)
 
         if (this.nop && changes.hasChanges) {
           resArray.push(new NopCommand('Repository', this.repo, null, results))
@@ -91,10 +91,16 @@ module.exports = class Repository extends ErrorStash {
         }
         const promises = []
         if (topicChanges.hasChanges) {
+          if (!this.nop) {
+            this.log.info(`Applying topic changes to ${this.repo.owner}/${this.repo.repo} (the diff is logged at debug level)`)
+          }
           promises.push(this.updatetopics(resp.data, resArray))
         }
         if (changes.hasChanges) {
           this.log.debug('There are repo changes')
+          if (!this.nop) {
+            this.log.info(`Applying repository settings changes to ${this.repo.owner}/${this.repo.repo} (the diff is logged at debug level)`)
+          }
           let updateDefaultBranchPromise = Promise.resolve()
           if (this.settings.default_branch && (resp.data.default_branch !== this.settings.default_branch)) {
             this.log.debug('There is a rename of the default branch')

--- a/test/unit/lib/plugins/autolinks.test.js
+++ b/test/unit/lib/plugins/autolinks.test.js
@@ -5,7 +5,7 @@ describe('Autolinks', () => {
   let github
 
   function configure (config) {
-    const log = { debug: jest.fn(), error: console.error }
+    const log = { debug: jest.fn(), info: jest.fn(), error: console.error }
     const nop = false
     const errors = []
     return new Autolinks(nop, github, repo, config, log, errors)

--- a/test/unit/lib/plugins/branches.test.js
+++ b/test/unit/lib/plugins/branches.test.js
@@ -8,6 +8,7 @@ describe('Branches', () => {
   const log = jest.fn()
   log.debug = jest.fn()
   log.error = jest.fn()
+  log.info = jest.fn()
 
   function configure (config) {
     const nop = false
@@ -70,6 +71,19 @@ describe('Branches', () => {
           restrictions: null,
           headers: { accept: 'application/vnd.github.hellcat-preview+json,application/vnd.github.luke-cage-preview+json,application/vnd.github.zzzax-preview+json' }
         })
+      })
+    })
+
+    it('logs the applied branch protection change at info level', () => {
+      const plugin = configure(
+        [{
+          name: 'master',
+          protection: { enforce_admins: true }
+        }]
+      )
+
+      return plugin.sync().then(() => {
+        expect(log.info).toHaveBeenCalledWith(expect.stringContaining('Applying branch protection changes to master branch of bkeepers/test'))
       })
     })
 
@@ -183,7 +197,6 @@ describe('Branches', () => {
         )
 
         return plugin.sync().then(() => {
-
           expect(github.rest.repos.updateBranchProtection).toHaveBeenCalledWith(expect.objectContaining({
             owner: 'bkeepers',
             repo: 'test',
@@ -305,7 +318,6 @@ describe('Branches', () => {
         )
 
         return plugin.sync().then(() => {
-
           expect(github.rest.repos.updateBranchProtection).toHaveBeenCalledWith(expect.objectContaining({
             owner: 'bkeepers',
             repo: 'test',

--- a/test/unit/lib/plugins/collaborators.test.js
+++ b/test/unit/lib/plugins/collaborators.test.js
@@ -4,7 +4,7 @@ describe('Collaborators', () => {
   let github
 
   function configure (config) {
-    const log = { debug: jest.fn(), error: console.error }
+    const log = { debug: jest.fn(), info: jest.fn(), error: console.error }
     return new Collaborators(undefined, github, { owner: 'bkeepers', repo: 'test' }, config, log)
   }
 

--- a/test/unit/lib/plugins/custom_properties.test.js
+++ b/test/unit/lib/plugins/custom_properties.test.js
@@ -23,7 +23,7 @@ describe('CustomProperties', () => {
       }
     }
 
-    log = { debug: jest.fn(), error: console.error }
+    log = { debug: jest.fn(), info: jest.fn(), error: console.error }
   })
 
   describe('Custom Properties plugin', () => {

--- a/test/unit/lib/plugins/environments.test.js
+++ b/test/unit/lib/plugins/environments.test.js
@@ -10,7 +10,7 @@ describe('Environments Plugin test suite', () => {
   const PrimaryEnvironmentNamesBeingTested = ['wait-timer_environment', 'wait-timer_2_environment', 'reviewers_environment', 'prevent-self-review_environment', 'deployment-branch-policy_environment', 'deployment-branch-policy-custom_environment', 'deployment-branch-policy-custom_environment_legacy', 'variables_environment', 'deployment-protection-rules_environment', 'new_environment', 'old_environment']
   const EnvironmentNamesForTheNewEnvironmentsTest = ['new-wait-timer', 'new-reviewers', 'new-prevent-self-review', 'new-deployment-branch-policy', 'new-deployment-branch-policy-custom', 'new-deployment-branch-policy-custom-legacy', 'new-variables', 'new-deployment-protection-rules']
   const AllEnvironmentNamesBeingTested = PrimaryEnvironmentNamesBeingTested.concat(EnvironmentNamesForTheNewEnvironmentsTest)
-  const log = { debug: jest.fn(), error: console.error }
+  const log = { debug: jest.fn(), info: jest.fn(), error: console.error }
   const errors = []
 
   function fillEnvironment (attrs) {
@@ -1409,7 +1409,7 @@ describe('nopifyRequest', () => {
     github = {
       request: jest.fn(() => Promise.resolve(true))
     };
-    plugin = new Environments(undefined, github, { owner: org, repo }, [], { debug: jest.fn(), error: console.error }, []);
+    plugin = new Environments(undefined, github, { owner: org, repo }, [], { debug: jest.fn(), info: jest.fn(), error: console.error }, []);
   });
 
   it('should make a request when nop is false', async () => {

--- a/test/unit/lib/plugins/labels.test.js
+++ b/test/unit/lib/plugins/labels.test.js
@@ -28,7 +28,7 @@ describe('Labels', () => {
         }
       }
     }
-    log = { debug: jest.fn(), error: console.error }
+    log = { debug: jest.fn(), info: jest.fn(), error: console.error }
   })
 
   describe('sync', () => {
@@ -50,6 +50,8 @@ describe('Labels', () => {
       ])
 
       return plugin.sync().then(() => {
+        expect(log.info).toHaveBeenCalledWith(expect.stringContaining('Applying Labels changes to bkeepers/test'))
+
         expect(github.rest.issues.deleteLabel).toHaveBeenCalledWith({
           owner: 'bkeepers',
           repo: 'test',

--- a/test/unit/lib/plugins/repository.test.js
+++ b/test/unit/lib/plugins/repository.test.js
@@ -17,6 +17,7 @@ describe('Repository', () => {
   const log = jest.fn()
   log.debug = jest.fn()
   log.error = jest.fn()
+  log.info = jest.fn()
 
   function configure (config) {
     const nop = false
@@ -43,6 +44,7 @@ describe('Repository', () => {
           description: 'Hello World!',
           mediaType: { previews: ['nebula-preview'] }
         })
+        expect(log.info).toHaveBeenCalledWith(expect.stringContaining('Applying repository settings changes to bkeepers/test'))
       })
     })
 
@@ -60,7 +62,7 @@ describe('Repository', () => {
       })
     })
 
-    it.only('syncs topics', () => {
+    it('syncs topics', () => {
       const plugin = configure({
         topics: ['foo', 'bar']
       })
@@ -74,6 +76,7 @@ describe('Repository', () => {
             previews: ['mercy']
           }
         })
+        expect(log.info).toHaveBeenCalledWith(expect.stringContaining('Applying topic changes to bkeepers/test'))
       })
     })
   })

--- a/test/unit/lib/plugins/rulesets.test.js
+++ b/test/unit/lib/plugins/rulesets.test.js
@@ -86,6 +86,7 @@ describe('Rulesets', () => {
   let github
   const log = jest.fn()
   log.debug = jest.fn()
+  log.info = jest.fn()
   log.error = jest.fn()
 
   function configure (config, scope='repo') {

--- a/test/unit/lib/plugins/teams.test.js
+++ b/test/unit/lib/plugins/teams.test.js
@@ -15,7 +15,7 @@ describe('Teams', () => {
   const org = 'bkeepers'
 
   function configure (config) {
-    const log = { debug: jest.fn(), error: console.error }
+    const log = { debug: jest.fn(), info: jest.fn(), error: console.error }
     const errors = []
     return new Teams(undefined, github, { owner: 'bkeepers', repo: 'test' }, config, log, errors)
   }

--- a/test/unit/lib/plugins/variables.test.js
+++ b/test/unit/lib/plugins/variables.test.js
@@ -8,7 +8,7 @@ describe('Variables', () => {
   const repo = 'test'
 
   function configure (nop = false, entries = [{ name: 'test', value: 'test' }]) {
-    const log = { debug: jest.fn(), error: console.error }
+    const log = { debug: jest.fn(), info: jest.fn(), error: console.error }
     const errors = []
     return new Variables(nop, github, { owner: org, repo }, entries, log, errors)
   }


### PR DESCRIPTION
Fixes #451.

When safe-settings applies changes (non-dry-run), nothing is visible above debug level: the diff computation, the "there are changes" decision, and the API call results are all `log.debug`. At the default log level a sync that rewrites branch protection across an org produces no trace of what it changed. HagegeR and tylerohlsen asked for exactly this in #451.

This PR adds one info-level line per applied change, in the three places changes are actually applied:

- `lib/plugins/diffable.js` (covers labels, teams, collaborators, autolinks, variables, rulesets, and the other diffable plugins): `Applying <Plugin> changes to <owner>/<repo>`
- `lib/plugins/branches.js`: `Applying branch protection changes to <branch> branch of <owner>/<repo>`
- `lib/plugins/repository.js`: separate lines for repository settings and topic changes

Each line points at the debug level for the full diff rather than embedding it. That's deliberate: diffs can contain config values (e.g. Actions variables), and per the review discussion on #1018 those shouldn't land in info-level logs. The full diffs were already logged at debug; that behavior is unchanged. Dry-run (nop) output is also unchanged.

Also fixes two debug statements in `repository.js` that interpolated objects into template strings and printed `Result of comparing repo for changes = [object Object]` (the bug @HagegeR pointed out in the issue comments, in its current location).