### PR TITLE
fix(mergedeep): preserve array shape when comparing empty targets

### DIFF
--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -89,8 +89,14 @@ class MergeDeep {
         additions = s.slice()
       } else {
         // Assign into the container passed by recursive callers so they observe
-        // the additions through their own reference.
-        additions = Object.assign(additions, s)
+        // the additions through their own reference. Copy keys explicitly to
+        // skip prototype pollution vectors, like the comparison loop does.
+        for (const key of Object.keys(s)) {
+          if (key === '__proto__' || key === 'constructor') {
+            continue
+          }
+          additions[key] = s[key]
+        }
       }
       return ({ additions, modifications, deletions, hasChanges: true })
     }

--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -82,8 +82,17 @@ class MergeDeep {
 
     // If the target is empty, then all the source is added to additions
     if (t === undefined || t === null || (this.isEmpty(t) && !this.isEmpty(s))) {
-      additions = Object.assign(additions, s)
-      return ({ additions, modifications, hasChanges: true })
+      if (firstInvocation && Array.isArray(s)) {
+        // Match the shape of the non-empty-target path, which unwinds the
+        // `__array` wrapper before returning: a top-level array diff must come
+        // back as an array, not as the index-keyed object Object.assign builds.
+        additions = s.slice()
+      } else {
+        // Assign into the container passed by recursive callers so they observe
+        // the additions through their own reference.
+        additions = Object.assign(additions, s)
+      }
+      return ({ additions, modifications, deletions, hasChanges: true })
     }
 
     // Compare the entries in the objects or elements of the array
@@ -92,8 +101,8 @@ class MergeDeep {
     // So any property in the target that is not in the source is not treated as a deletion
     for (const key in source) {
       // Skip prototype pollution vectors
-      if (key === "__proto__" || key === "constructor") {
-        continue;
+      if (key === '__proto__' || key === 'constructor') {
+        continue
       }
       // Logic specific for Github
       // API response includes urls for resources, or other ignorable fields; we can ignore them

--- a/test/unit/lib/mergeDeep.test.js
+++ b/test/unit/lib/mergeDeep.test.js
@@ -809,6 +809,7 @@ entries:
         ]
       },
       modifications: {},
+      deletions: {},
       hasChanges: true
     }
     const ignorableFields = []
@@ -1881,5 +1882,29 @@ branches:
     console.log(`new diffs ${JSON.stringify(same, null, 2)}`)
     expect(same.additions).toEqual({})
     expect(same.modifications).toEqual({})
+  })
+
+  it('CompareDeep returns top-level array additions in the same shape for empty and non-empty targets', () => {
+    const mergeDeep = new MergeDeep(log, jest.fn(), [])
+    const ruleset = { name: 'first-ruleset', enforcement: 'active' }
+
+    // Target already has an entry: additions come back as an array
+    const withExisting = mergeDeep.compareDeep(
+      [{ name: 'other', enforcement: 'active' }],
+      [{ name: 'other', enforcement: 'active' }, ruleset]
+    )
+    expect(withExisting.additions).toEqual([ruleset])
+
+    // Empty target (e.g. a repo receiving its first ruleset) must produce the
+    // same shape, not an index-keyed object like { 0: { ... } }
+    const firstEntry = mergeDeep.compareDeep([], [ruleset])
+    expect(firstEntry.additions).toEqual([ruleset])
+    expect(firstEntry.hasChanges).toEqual(true)
+  })
+
+  it('CompareDeep always includes deletions in its result', () => {
+    const mergeDeep = new MergeDeep(log, jest.fn(), [])
+    const emptyTarget = mergeDeep.compareDeep([], [{ name: 'a' }])
+    expect(emptyTarget).toHaveProperty('deletions')
   })
 })

--- a/test/unit/lib/mergeDeep.test.js
+++ b/test/unit/lib/mergeDeep.test.js
@@ -1907,4 +1907,13 @@ branches:
     const emptyTarget = mergeDeep.compareDeep([], [{ name: 'a' }])
     expect(emptyTarget).toHaveProperty('deletions')
   })
+
+  it('CompareDeep skips prototype pollution vectors when the target is empty', () => {
+    const mergeDeep = new MergeDeep(log, jest.fn(), [])
+    // JSON.parse creates `__proto__` as an own key, unlike object literals
+    const source = JSON.parse('{"name": "a", "__proto__": { "polluted": true }}')
+    const result = mergeDeep.compareDeep({}, source)
+    expect(result.additions).toEqual({ name: 'a' })
+    expect(result.additions.polluted).toBeUndefined()
+  })
 })


### PR DESCRIPTION
`MergeDeep.compareDeep` reports the same kind of change in two different JSON shapes depending on whether the target is empty. Comparing rulesets (any top-level array config works the same):

```js
// repo already has a ruleset: additions is an array
compareDeep([{ name: 'other', ... }], [{ name: 'other', ... }, { name: 'new', ... }])
// => { additions: [ { name: 'new', ... } ], ... }

// repo receives its FIRST ruleset: additions is an index-keyed object
compareDeep([], [{ name: 'new', ... }])
// => { additions: { "0": { name: 'new', ... } }, ... }
```

Two details combine to cause this. On first invocation, top-level arrays are wrapped into `{ __array: [...] }` before the accumulator-type check runs, so `Array.isArray(source)` is always false and `additions` initializes as `{}` (the array branch of that check is effectively dead code). The non-empty-target path recovers because the `__array` key is processed as a nested array and unwound before returning. But the empty-target early return does `Object.assign(additions, s)` — spreading an array into a plain object produces the `{ "0": ..., "1": ... }` shape — and returns without the unwind. That early return also omits `deletions` from its result, unlike every other return path.

This hits anything consuming plan/diff JSON — dry-run reports, PR comments, or tooling parsing the NopCommand actions. A repo receiving its first ruleset reports index-keyed attribute soup instead of one added item, while the second ruleset onward reports a clean array. (Possibly related to the inconsistent-diff reports in #693).