### PR TITLE
fix(rulesets): resolve {{EXTERNALLY_DEFINED}} before diffing (incorporate PR #1023)

### DIFF
--- a/lib/plugins/diffable.js
+++ b/lib/plugins/diffable.js
@@ -74,6 +74,11 @@ module.exports = class Diffable extends ErrorStash {
       let filteredEntries = this.filterEntries()
       // this.log.debug(`filtered entries are ${JSON.stringify(filteredEntries)}`)
       return this.find().then(existingRecords => {
+        // Let plugins resolve config placeholders (e.g. {{EXTERNALLY_DEFINED}}) against
+        // the live records before any comparison, so placeholders never report changes.
+        if (typeof this.resolveOverrides === 'function') {
+          filteredEntries = this.resolveOverrides(existingRecords, filteredEntries)
+        }
         this.log.debug(` ${JSON.stringify(existingRecords, null, 2)} \n\n ${JSON.stringify(filteredEntries, null, 2)} `)
 
         const mergeDeep = new MergeDeep(this.log, this.github, ignorableFields)

--- a/lib/plugins/rulesets.js
+++ b/lib/plugins/rulesets.js
@@ -239,6 +239,17 @@ module.exports = class Rulesets extends Diffable {
     return existing.name === attrs.name
   }
 
+  // Resolve {{EXTERNALLY_DEFINED}} placeholders against the matching live ruleset
+  // before diffing, mirroring how branches.js resolves overrides inside its
+  // comparison. Without this the comparison sees the literal placeholder string,
+  // so every plan reports an update for rulesets that use overrides.
+  resolveOverrides (existingRecords, entries) {
+    return entries.map(attrs => {
+      const existing = existingRecords.find(record => this.comparator(record, attrs))
+      return Overrides.removeOverrides(overrides, structuredClone(attrs), existing || {})
+    })
+  }
+
   changed (existing, attrs) {
     const mergeDeep = new MergeDeep(this.log, this.github, ignorableFields)
     const merged = mergeDeep.compareDeep(existing, attrs)

--- a/test/unit/lib/plugins/rulesets.test.js
+++ b/test/unit/lib/plugins/rulesets.test.js
@@ -292,7 +292,7 @@ describe('Rulesets', () => {
   })
 
   describe('when {{EXTERNALLY_DEFINED}} is present in "required_status_checks" and status checks exist in GitHub', () => {
-    it('it retains the status checks from GitHub and everything else is reset to the safe-settings', () => {
+    it('skips the placeholder-only ruleset and updates the genuinely changed ones', () => {
       // Mock the GitHub API response
       github.paginate = jest.fn().mockResolvedValue([
         generateRequestRuleset(
@@ -355,21 +355,11 @@ describe('Rulesets', () => {
       )
 
       return plugin.sync().then(() => {
+        // Ruleset 1 only differs by the {{EXTERNALLY_DEFINED}} placeholder, which
+        // resolves to the live status checks, so it must not be updated at all.
+        expect(github.request).toHaveBeenCalledTimes(2)
         expect(github.request).toHaveBeenNthCalledWith(
           1,
-          'PUT /repos/{owner}/{repo}/rulesets/{id}',
-          generateResponseRuleset(
-            1,
-            'All branches 1',
-            repo_conditions,
-            [
-              { context: 'Custom Check 1' },
-              { context: 'Custom Check 2' }
-            ]
-          )
-        )
-        expect(github.request).toHaveBeenNthCalledWith(
-          2,
           'PUT /repos/{owner}/{repo}/rulesets/{id}',
           generateResponseRuleset(
             2,
@@ -382,7 +372,7 @@ describe('Rulesets', () => {
           )
         )
         expect(github.request).toHaveBeenNthCalledWith(
-          3,
+          2,
           'PUT /repos/{owner}/{repo}/rulesets/{id}',
           generateResponseRuleset(
             3,
@@ -473,7 +463,7 @@ describe('Rulesets', () => {
   })
 
   describe('[org] when {{EXTERNALLY_DEFINED}} is present in "required_status_checks" and status checks exist in GitHub', () => {
-    it('it retains the status checks from GitHub', () => {
+    it('reports no changes when only the placeholder differs from GitHub', () => {
       // Mock the GitHub API response
       github.paginate = jest.fn().mockResolvedValue([
         generateRequestRuleset(
@@ -506,20 +496,48 @@ describe('Rulesets', () => {
       )
 
       return plugin.sync().then(() => {
-        expect(github.request).toHaveBeenNthCalledWith(
-          1,
-          'PUT /orgs/{org}/rulesets/{id}',
-          generateResponseRuleset(
-            1,
-            'All branches 1',
-            org_conditions,
-            [
-              { context: 'Custom Check 1' },
-              { context: 'Custom Check 2' }
-            ],
-            true
-          )
-        )
+        // The placeholder resolves to the live status checks, so the ruleset is unchanged
+        expect(github.request).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('in nop mode', () => {
+    beforeEach(() => {
+      github.request.endpoint = Object.assign(
+        jest.fn().mockImplementation((route, parms) => { return { url: route, body: parms } }),
+        { merge: github.request.endpoint.merge }
+      )
+    })
+
+    it('does not plan an update when {{EXTERNALLY_DEFINED}} matches the status checks in GitHub', () => {
+      github.paginate = jest.fn().mockResolvedValue([
+        generateRequestRuleset(1, 'All branches 1', repo_conditions, [{ context: 'Custom Check 1' }])
+      ])
+
+      const plugin = configure([
+        generateRequestRuleset(1, 'All branches 1', repo_conditions, [{ context: '{{EXTERNALLY_DEFINED}}' }])
+      ], 'repo', true)
+
+      return plugin.sync().then(res => {
+        // sync resolves with nothing when no changes are detected
+        const messages = (res || []).flat(2).map(nopCommand => nopCommand.action?.msg)
+        expect(messages).not.toContain('Update Ruleset')
+      })
+    })
+
+    it('still plans an update when the config genuinely differs from GitHub', () => {
+      github.paginate = jest.fn().mockResolvedValue([
+        generateRequestRuleset(1, 'All branches 1', repo_conditions, [{ context: 'Custom Check 1' }])
+      ])
+
+      const plugin = configure([
+        generateRequestRuleset(1, 'All branches 1', repo_conditions, [{ context: 'Other Check' }])
+      ], 'repo', true)
+
+      return plugin.sync().then(res => {
+        const messages = res.flat(2).map(nopCommand => nopCommand.action?.msg)
+        expect(messages).toContain('Update Ruleset')
       })
     })
   })


### PR DESCRIPTION
## Why

Rulesets that use the `{{EXTERNALLY_DEFINED}}` placeholder (e.g. in `required_status_checks`) were falsely reported as changed on every run. This branch already resolved the placeholder inside `update()`/`add()`, but only on the apply (non-nop) path, so the comparison still saw the literal placeholder string. The result: dry runs reported a redundant "Update Ruleset" and apply mode issued a redundant PUT even when nothing had actually changed (fixes the behavior in #1022).

This incorporates the fix from upstream PR #1023 into the comprehensive `yadhav/fix-recent-issues` line, where it was not yet handled.

## Approach

`Diffable.sync()` now exposes an optional `resolveOverrides(existingRecords, filteredEntries)` hook, called after `find()` and before the comparison. Plugins can opt in to resolve config placeholders against the live records so placeholders never register as differences.

The rulesets plugin implements the hook: each config entry is matched to its live record (via the existing `comparator`) and passed through `Overrides.removeOverrides`, so `{{EXTERNALLY_DEFINED}}` resolves to the live values before `changed()` ever runs. This mirrors how `branches.js` already resolves overrides inside its `compareDeep` call. The hook is opt-in per plugin, so no other diffable plugin changes behavior.

## Notes for reviewers

- **Intentional behavior change:** a ruleset whose only difference from GitHub is the placeholder no longer plans an update in dry runs and no longer issues a PUT in apply mode. Rulesets with real differences behave exactly as before, since resolution happens against the same live record `update()` would have used.
- Entries are cloned with `structuredClone` before resolution because `removeOverrides` mutates its input, so the loaded config is never modified.
- This branch's `overrides` object uses `action: 'delete'` for `required_status_checks`, which short-circuits before the `type` check, so the `array` vs `dict` type difference from PR #1023 is a no-op here and was left as-is.

## Testing

- Unit tests: 340/340 passing. Updated the two affected `{{EXTERNALLY_DEFINED}}` tests to the new behavior and added nop-mode coverage (placeholder-only match plans no update; a genuine diff still plans an update).
- Smoke test: ran the full end-to-end suite against a live org. Every ruleset apply phase passed (repo/suborg ruleset creation, rulesets additive/disable_plugins, name/slug resolution). The only failures were pre-existing environmental issues unrelated to this change (drift-injection steps needing broader `gh` CLI scopes, and the enterprise app_installations phase).