### PR TITLE
fix(configManager): rethrow errors instead of masking them as a TypeError

### DIFF
--- a/lib/configManager.js
+++ b/lib/configManager.js
@@ -21,6 +21,7 @@ module.exports = class ConfigManager {
       const params = Object.assign(repo, { path: filePath, ref: this.ref })
       const response = await this.context.octokit.rest.repos.getContent(params).catch(e => {
         this.log.error(`Error getting settings ${e}`)
+        throw e
       })
 
       // Ignore in case path is a folder

--- a/test/unit/lib/configManager.test.js
+++ b/test/unit/lib/configManager.test.js
@@ -1,0 +1,100 @@
+/* eslint-disable no-undef */
+const ConfigManager = require('../../../lib/configManager')
+
+describe('configManager', () => {
+  let context
+
+  beforeEach(() => {
+    context = {
+      repo: () => { return { owner: 'test-org', repo: 'admin' } },
+      octokit: {
+        rest: {
+          repos: {
+            getContent: jest.fn()
+          }
+        }
+      },
+      log: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        error: jest.fn()
+      }
+    }
+  })
+
+  describe('loadYaml', () => {
+    it('returns the parsed YAML content when the file is fetched successfully', async () => {
+      const configManager = new ConfigManager(context, 'main')
+      context.octokit.rest.repos.getContent.mockResolvedValue({
+        data: { content: Buffer.from('key: value').toString('base64') }
+      })
+
+      const result = await configManager.loadYaml('.github/settings.yml')
+
+      expect(result).toEqual({ key: 'value' })
+      expect(context.octokit.rest.repos.getContent).toHaveBeenCalledWith({
+        owner: 'test-org',
+        repo: 'admin',
+        path: '.github/settings.yml',
+        ref: 'main'
+      })
+    })
+
+    it('returns null when the path is a folder', async () => {
+      const configManager = new ConfigManager(context, 'main')
+      context.octokit.rest.repos.getContent.mockResolvedValue({ data: [] })
+
+      await expect(configManager.loadYaml('.github')).resolves.toBeNull()
+    })
+
+    it('returns undefined when the path is a symlink or submodule', async () => {
+      const configManager = new ConfigManager(context, 'main')
+      context.octokit.rest.repos.getContent.mockResolvedValue({ data: { content: null } })
+
+      await expect(configManager.loadYaml('.github/settings.yml')).resolves.toBeUndefined()
+    })
+
+    it('returns null when the file does not exist', async () => {
+      const configManager = new ConfigManager(context, 'main')
+      const notFound = new Error('Not Found')
+      notFound.status = 404
+      context.octokit.rest.repos.getContent.mockRejectedValue(notFound)
+
+      await expect(configManager.loadYaml('.github/settings.yml')).resolves.toBeNull()
+    })
+
+    it('propagates a non-404 error instead of masking it', async () => {
+      const configManager = new ConfigManager(context, 'main')
+      const serverError = new Error('Internal Server Error')
+      serverError.status = 500
+      context.octokit.rest.repos.getContent.mockRejectedValue(serverError)
+
+      await expect(configManager.loadYaml('.github/settings.yml')).rejects.toThrow('Internal Server Error')
+    })
+
+    it('propagates the original error object so its status is preserved', async () => {
+      const configManager = new ConfigManager(context, 'main')
+      const forbidden = new Error('Forbidden')
+      forbidden.status = 403
+      context.octokit.rest.repos.getContent.mockRejectedValue(forbidden)
+
+      await expect(configManager.loadYaml('.github/settings.yml')).rejects.toBe(forbidden)
+    })
+  })
+
+  describe('loadGlobalSettingsYaml', () => {
+    it('loads the settings file from the configured config path', async () => {
+      const configManager = new ConfigManager(context, 'main')
+      context.octokit.rest.repos.getContent.mockResolvedValue({
+        data: { content: Buffer.from('repository:\n  has_wiki: false').toString('base64') }
+      })
+
+      const result = await configManager.loadGlobalSettingsYaml()
+
+      expect(result).toEqual({ repository: { has_wiki: false } })
+      expect(context.octokit.rest.repos.getContent).toHaveBeenCalledWith(
+        expect.objectContaining({ path: '.github/settings.yml' })
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Problem

`ConfigManager.loadYaml` handles a failed `repos.getContent` in a `.catch()` that logs the error but neither rethrows nor returns a value:

https://github.com/github-community-projects/safe-settings/blob/main-enterprise/lib/configManager.js#L22-L30

So the awaited expression resolves to `undefined`, and the very next statement dereferences `response.data`. Every failure to read the config file therefore surfaces as:

```
ERROR (probot): Error getting settings HttpError: Not Found
Unexpected error during full sync: TypeError: Cannot read properties of undefined (reading 'data')
```

Two consequences:

1. **The real error is lost.** The `TypeError` has no `.status`, so the `if (e.status === 404) return null` in the enclosing `catch` never matches and rethrows it instead. A missing settings file aborts the run rather than returning `null` as the code plainly intends.
2. **Every cause looks identical.** 404 (no admin repo / no settings file / wrong `CONFIG_PATH` / wrong account), 403 (permissions, rate limit) and 5xx all produce the same `reading 'data'` `TypeError`, pointing at a line that is not where anything went wrong.

That error string shows up in issue reports where it obscured the actual cause — it is the error output in #782, and the same masking pattern is visible in #586. We lost about two days to it: the underlying failure was a plain 404 on the config repo, and nothing in the logs said so.

## Change

Add `throw e` to the `.catch()`. `lib/settings.js` already does exactly this in its equivalent `.catch()`:

https://github.com/github-community-projects/safe-settings/blob/main-enterprise/lib/settings.js#L865-L874

so this brings `configManager` in line with the working version in the same codebase. With the fix, a 404 returns `null` through the existing `catch`, and any other error propagates unchanged with its `status` intact.

Behaviour change worth calling out: a non-404 config read error now fails the sync with the real HTTP error instead of a `TypeError`. Both abort, so nothing that used to succeed starts failing — only the reported error changes, and a 404 now correctly returns `null` instead of aborting.

## Tests

`lib/configManager.js` had no test file. Added `test/unit/lib/configManager.test.js` (7 tests) covering the success path, folder and symlink responses, `loadGlobalSettingsYaml` path composition, and the two error paths: 404 resolves to `null`, and a non-404 rejects with the original error object so its `status` survives.

3 of the 7 fail on `main-enterprise` without the change, with `Received message: "Cannot read properties of undefined (reading 'data')"` — i.e. the suite reproduces the reported failure and then pins the fix.

```
npx jest test/unit/lib/configManager.test.js  -> 7 passed
npx jest --roots=lib --roots=test/unit        -> 144 passed, 14 skipped (137 passed before, no regressions)
npx standard lib/configManager.js test/unit/lib/configManager.test.js  -> clean
npx eslint   lib/configManager.js test/unit/lib/configManager.test.js  -> clean
```

Node 22.12.0.
