### PR TITLE
fix: sync the installation matching GH_ORG during full sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # The organization where you want to register the app in the app creation manifest flow.
 # If set, the app is registered for an organization (https://github.com/organizations/ORGANIZATION/settings/apps/new),
 # if not set, the GitHub app would be registered for the user account (https://github.com/settings/apps/new).
+# It also scopes the full sync: the installation on this account is the one that
+# gets synced, instead of whichever installation the API lists first.
 # GH_ORG=
 
 # The ID of your GitHub App

--- a/README.md
+++ b/README.md
@@ -549,6 +549,19 @@ You can pass environment variables; the easiest way to do it is via a `.env` fil
   ```
   BLOCK_REPO_RENAME_BY_HUMAN=true
   ```
+1. Scope the full sync to one account using `GH_ORG`. For e.g.
+  ```
+  GH_ORG=my-org
+  ```
+  If the app is installed on more than one account, a full sync (`CRON` or
+  `npm run full-sync`) picks the installation on the `GH_ORG` account and reads
+  its configuration from `GH_ORG/<ADMIN_REPO>`. If `GH_ORG` is set but the app
+  is not installed on it, the full sync fails instead of syncing a different
+  account. When `GH_ORG` is not set, the first installation returned by the API
+  is used, so setting it is recommended whenever the app is installed on more
+  than one account. Note that `GH_ORG` is also used by the
+  [manifest flow](https://docs.github.com/en/apps/sharing-github-apps/registering-a-github-app-from-a-manifest)
+  to decide which account the app is registered for.
 
 
 ### Runtime Settings

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -14,6 +14,8 @@ Running a full-sync with `safe-settings` can be done via `npm run full-sync`. Th
 ### Example GHA Workflow
 The below example uses the GHA "cron" feature to run a full-sync every 4 hours. While not required, this example uses the `.github` repo as the `admin` repo (set via `ADMIN_REPO` env var) and the safe-settings configurations are stored in the `safe-settings/` directory (set via `CONFIG_PATH` and `DEPLOYMENT_CONFIG_FILE`).
 
+`GH_ORG` names the account to sync. If the App is installed on more than one account, set it: it selects the installation to sync, and the full-sync fails rather than syncing a different account if the App is not installed on it.
+
 ```yaml
 name: Safe Settings Sync
 on:

--- a/index.js
+++ b/index.js
@@ -231,8 +231,24 @@ module.exports = (robot, { getRouter }, Settings = require('./lib/settings')) =>
       github.rest.apps.listInstallations.endpoint.merge({ per_page: 100 })
     )
 
-    if (installations.length > 0) {
-      const installation = installations[0]
+    // When GH_ORG is set, sync the installation on that account instead of
+    // whichever one the API happens to list first. The order of
+    // `GET /app/installations` is not guaranteed to keep the account you care
+    // about at index 0, so an app installed on more than one account can
+    // otherwise start reading its config from, and applying settings to, a
+    // different account than the operator intended. Without GH_ORG the
+    // behavior is unchanged.
+    const installation = env.GH_ORG
+      ? installations.find(i => i.account?.login?.toLowerCase() === env.GH_ORG.toLowerCase())
+      : installations[0]
+
+    if (env.GH_ORG && !installation) {
+      const accounts = installations.map(i => i.account?.login).join(', ')
+      throw new Error(`No app installation found for GH_ORG '${env.GH_ORG}'. Installed on: [${accounts}]`)
+    }
+
+    if (installation) {
+      robot.log.info(`Syncing installation ${installation.id} on account ${installation.account?.login}`)
       const github = await robot.auth(installation.id)
       const context = {
         payload: {

--- a/lib/env.js
+++ b/lib/env.js
@@ -7,6 +7,7 @@ module.exports = {
   CREATE_ERROR_ISSUE: process.env.CREATE_ERROR_ISSUE || 'true',
   BLOCK_REPO_RENAME_BY_HUMAN: process.env.BLOCK_REPO_RENAME_BY_HUMAN || 'false',
   FULL_SYNC_NOP: process.env.FULL_SYNC_NOP === 'true',
+  GH_ORG: process.env.GH_ORG,
   GHE_HOST: process.env.GHE_HOST,
   GHE_PROTOCOL: process.env.GHE_PROTOCOL,
 }

--- a/test/unit/lib/env.test.js
+++ b/test/unit/lib/env.test.js
@@ -32,6 +32,11 @@ describe('env', () => {
       const FULL_SYNC_NOP = envTest.FULL_SYNC_NOP
       expect(FULL_SYNC_NOP).toEqual(false)
     })
+
+    it('leaves GH_ORG undefined if not passed', () => {
+      const GH_ORG = envTest.GH_ORG
+      expect(GH_ORG).toBeUndefined()
+    })
   })
 
   describe('load override values', () => {
@@ -43,6 +48,7 @@ describe('env', () => {
       process.env.DEPLOYMENT_CONFIG_FILE = 'safe-settings-deployment.yml'
       process.env.CREATE_PR_COMMENT = 'false'
       process.env.FULL_SYNC_NOP = false
+      process.env.GH_ORG = 'my-org'
     })
 
     it('loads override values if passed', () => {
@@ -59,6 +65,8 @@ describe('env', () => {
       expect(CREATE_PR_COMMENT).toEqual('false')
       const FULL_SYNC_NOP = envTest.FULL_SYNC_NOP
       expect(FULL_SYNC_NOP).toEqual(false)
+      const GH_ORG = envTest.GH_ORG
+      expect(GH_ORG).toEqual('my-org')
     })
   })
 })

--- a/test/unit/sync-installation.test.js
+++ b/test/unit/sync-installation.test.js
@@ -1,0 +1,171 @@
+/* eslint-disable no-undef */
+const path = require('path')
+
+// The plugin reads GH_ORG through lib/env, which snapshots process.env at
+// require time, so each scenario needs a freshly required copy of both.
+function loadPlugin (ghOrg) {
+  jest.resetModules()
+  if (ghOrg === undefined) {
+    delete process.env.GH_ORG
+  } else {
+    process.env.GH_ORG = ghOrg
+  }
+  return require('../../index')
+}
+
+function installation (id, login) {
+  return { id, account: { login } }
+}
+
+describe('syncInstallation', () => {
+  const originalGhOrg = process.env.GH_ORG
+  const originalDeploymentConfigFile = process.env.DEPLOYMENT_CONFIG_FILE
+  let robot, octokit, syncAll
+
+  beforeAll(() => {
+    // Point the deployment config at a file that does not exist so
+    // loadYamlFileSystem() falls back to its built-in defaults instead of
+    // picking up whatever happens to sit in the working directory.
+    process.env.DEPLOYMENT_CONFIG_FILE = path.join(__dirname, 'no-such-deployment-settings.yml')
+  })
+
+  afterAll(() => {
+    if (originalGhOrg === undefined) {
+      delete process.env.GH_ORG
+    } else {
+      process.env.GH_ORG = originalGhOrg
+    }
+    if (originalDeploymentConfigFile === undefined) {
+      delete process.env.DEPLOYMENT_CONFIG_FILE
+    } else {
+      process.env.DEPLOYMENT_CONFIG_FILE = originalDeploymentConfigFile
+    }
+  })
+
+  beforeEach(() => {
+    octokit = {
+      paginate: jest.fn(),
+      rest: {
+        apps: {
+          listInstallations: { endpoint: { merge: jest.fn(options => options) } },
+          getAuthenticated: jest.fn().mockResolvedValue({ data: { slug: 'safe-settings' } })
+        },
+        repos: {
+          // The global settings file is irrelevant here: these tests assert
+          // which installation is selected, not what gets synced.
+          getContent: jest.fn().mockResolvedValue({ data: { content: '' } })
+        }
+      }
+    }
+    robot = {
+      auth: jest.fn().mockResolvedValue(octokit),
+      log: Object.assign(jest.fn(), {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        trace: jest.fn()
+      }),
+      on: jest.fn()
+    }
+    syncAll = jest.fn().mockResolvedValue({ errors: [] })
+  })
+
+  // Returns the `repo` argument Settings.syncAll was called with, i.e. the
+  // admin repo of the account safe-settings decided to sync.
+  function syncedRepo () {
+    expect(syncAll).toHaveBeenCalledTimes(1)
+    return syncAll.mock.calls[0][2]
+  }
+
+  it('syncs the installation matching GH_ORG, not the first one listed', async () => {
+    const plugin = loadPlugin('my-org')
+    octokit.paginate.mockResolvedValue([
+      installation(1, 'another-account'),
+      installation(2, 'my-org')
+    ])
+
+    const app = plugin(robot, {}, { syncAll, handleError: jest.fn() })
+    await app.syncInstallation()
+
+    expect(syncedRepo()).toEqual({ owner: 'my-org', repo: 'admin' })
+    // The context handed to syncAll must be authenticated as the GH_ORG
+    // installation. (info() separately authenticates as installations[0] to
+    // read the app slug; that is left as-is, see the PR description.)
+    expect(robot.auth).toHaveBeenLastCalledWith(2)
+  })
+
+  it('matches GH_ORG case-insensitively, as GitHub account names are', async () => {
+    const plugin = loadPlugin('My-Org')
+    octokit.paginate.mockResolvedValue([
+      installation(1, 'another-account'),
+      installation(7, 'my-org')
+    ])
+
+    const app = plugin(robot, {}, { syncAll, handleError: jest.fn() })
+    await app.syncInstallation()
+
+    expect(syncedRepo()).toEqual({ owner: 'my-org', repo: 'admin' })
+  })
+
+  it('throws when GH_ORG has no installation instead of syncing another account', async () => {
+    const plugin = loadPlugin('my-org')
+    octokit.paginate.mockResolvedValue([
+      installation(1, 'another-account'),
+      installation(2, 'yet-another-account')
+    ])
+
+    const app = plugin(robot, {}, { syncAll, handleError: jest.fn() })
+
+    await expect(app.syncInstallation()).rejects.toThrow(
+      "No app installation found for GH_ORG 'my-org'. Installed on: [another-account, yet-another-account]"
+    )
+    expect(syncAll).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the first installation when GH_ORG is not set', async () => {
+    const plugin = loadPlugin(undefined)
+    octokit.paginate.mockResolvedValue([
+      installation(1, 'first-account'),
+      installation(2, 'second-account')
+    ])
+
+    const app = plugin(robot, {}, { syncAll, handleError: jest.fn() })
+    await app.syncInstallation()
+
+    expect(syncedRepo()).toEqual({ owner: 'first-account', repo: 'admin' })
+  })
+
+  it('returns null without syncing when the app has no installations', async () => {
+    const plugin = loadPlugin(undefined)
+    octokit.paginate.mockResolvedValue([])
+
+    const app = plugin(robot, {}, { syncAll, handleError: jest.fn() })
+
+    await expect(app.syncInstallation()).resolves.toBeNull()
+    expect(syncAll).not.toHaveBeenCalled()
+  })
+
+  it('passes the nop flag through to the sync', async () => {
+    const plugin = loadPlugin('my-org')
+    octokit.paginate.mockResolvedValue([installation(2, 'my-org')])
+
+    const app = plugin(robot, {}, { syncAll, handleError: jest.fn() })
+    await app.syncInstallation(true)
+
+    expect(syncAll).toHaveBeenCalledWith(true, expect.anything(), expect.anything(), expect.anything())
+  })
+
+  it('logs which account is being synced', async () => {
+    const plugin = loadPlugin('my-org')
+    octokit.paginate.mockResolvedValue([
+      installation(1, 'another-account'),
+      installation(2, 'my-org')
+    ])
+
+    const app = plugin(robot, {}, { syncAll, handleError: jest.fn() })
+    await app.syncInstallation()
+
+    expect(robot.log.info).toHaveBeenCalledWith('Syncing installation 2 on account my-org')
+  })
+})


### PR DESCRIPTION
Fixes #782.

## Problem

`syncInstallation()` paginates `apps.listInstallations` and then unconditionally takes the first entry, deriving the admin repo owner from it:

https://github.com/github-community-projects/safe-settings/blob/main-enterprise/index.js#L234-L246

So when an app is installed on more than one account, *which* account a full sync reconciles is decided by the order `GET /app/installations` happens to return. That order is not documented as stable, and it is **not** creation order — in our case the API returned an unrelated account ahead of ours even though its installation id was higher (`<other-account>#152779721` before `<ours>#138202905`).

This is not only about deployments that intend to manage several orgs. `GET /app/installations` lists installations for the *app*, and anyone can install a **public** app. Our app was public, an unrelated organisation installed it, and it took over index 0. From then on every scheduled sync read `<other-account>/admin/.github/settings.yml`, got a 404, and failed — our org silently went unmanaged for about two days. Had that account happened to contain an `admin` repo with a settings file, the sync would have applied *their* configuration to *their* org using our app's credentials. The operator has no way to express "only ever sync this account".

The natural way to say that already exists: `GH_ORG`. The GitHub Action recipe in `docs/github-action.md` sets it in the full-sync workflow, so operators reasonably assume it scopes the sync — but nothing read it. It was absent from `lib/env.js` and only consumed by the probot manifest flow.

## Change

- Add `GH_ORG` to `lib/env.js`.
- When `GH_ORG` is set, select the installation whose account login matches it, case-insensitively (GitHub account names are).
- When `GH_ORG` is set but the app has no installation on it, `throw` instead of silently falling back, so a mistargeted sync fails loudly rather than reconciling another account. The message lists the accounts the app *is* installed on, which is what one needs to debug it. `full-sync.js` already turns a throw into a non-zero exit with the message.
- When `GH_ORG` is **not** set, behaviour is unchanged (`installations[0]`). The change is opt-in and no existing deployment is affected.
- Log at `info` which installation and account is being synced. Nothing on the full-sync path recorded the account it acted on, which is a large part of why the above took two days to spot.

`info()` is deliberately left alone: it authenticates as an arbitrary installation purely to read the app slug, which is a property of the app, not of any one installation.

### Relationship to earlier attempts

#783 (@hilmarf) proposed the same idea and was closed by its author after going stale. Two things blocked it, both addressed here:

- @decyjphr's review point was that `GH_ORG` "is not a required env variable so in most cases it would not be set". #783 made the `find()` unconditional, so an unset `GH_ORG` would have matched nothing and every existing deployment would have stopped syncing. Here the filter only applies when `GH_ORG` is set, and `installations[0]` remains the default — which is also what @Simon-Boyer suggested on that thread.
- #783 read `env.GH_ORG`, but `GH_ORG` was never in `lib/env.js`, so it was `undefined` regardless of the environment. This PR adds it.
- @renan-alm noted the remaining work was tests. This PR has them.

#1044 makes full sync iterate *all* installations. The two are complementary rather than competing: that PR is about not skipping orgs you own, this one is about not syncing accounts you don't. If #1044 lands, `GH_ORG` becomes a filter over its loop rather than a pick-one, and I am happy to rebase into that shape.

The failure mode this creates is much easier to read once #1052 stops `configManager` from masking config-read errors as `TypeError: Cannot read properties of undefined (reading 'data')`; that is what the 404 above surfaced as. The two PRs are independent and touch different files.

## Tests

New `test/unit/sync-installation.test.js` (7 tests), driving the exported plugin with a fake `robot` and the injectable `Settings` argument, asserting on the `repo` handed to `Settings.syncAll`:

- two installations, `GH_ORG` matching the second -> that one is synced, and the context is authenticated as it
- `GH_ORG` differing in case from the account name -> still matched
- `GH_ORG` with no matching installation -> rejects, listing the installed accounts, and nothing is synced
- `GH_ORG` unset -> falls back to the first installation
- no installations -> resolves to `null`, nothing synced
- the `nop` flag is passed through
- the account being synced is logged

Reverting `index.js` and `lib/env.js` to `main-enterprise` fails 4 of the 7, so the suite pins the new behaviour rather than passing alongside it. `test/unit/lib/env.test.js` gains `GH_ORG` coverage in both the default and override blocks (1 further failure when reverted).

```
npx jest test/unit/sync-installation.test.js  -> 7 passed
npx jest --roots=lib --roots=test/unit        -> 145 passed, 14 skipped (137 passed before, no regressions)
npx standard <changed files>  -> clean
npx eslint   <changed files>  -> clean
```

Node 22.12.0.

Heads-up so it is not attributed to this PR: `npx eslint index.js lib/env.js` reports `index.js:5:7 'Glob' is assigned a value but never used` and a `comma-dangle` error in `lib/env.js`. Both are **pre-existing on `main-enterprise`** (verified by linting the pristine files; my added line only shifts the `env.js` one from line 11 to 12). Fixing them felt like it belonged in a separate cleanup PR.

## Docs

`README.md` (environment variables), `.env.example` and `docs/github-action.md` now state what `GH_ORG` does for a full sync.

## Possible follow-up

The `CRON` tick calls `syncInstallation()` without a rejection handler, so in the server flow this throw would become an unhandled rejection — as would any error thrown from `syncAllSettings` today, so it is not new. Adding a `.catch()` there seemed out of scope, but I am happy to include it if you would prefer.
